### PR TITLE
AuthType refactoring

### DIFF
--- a/src/Network/Transport/ZMQ/Internal/Types.hs
+++ b/src/Network/Transport/ZMQ/Internal/Types.hs
@@ -60,7 +60,7 @@ import qualified System.ZMQ4 as ZMQ
 -- | Parameters for ZeroMQ connection.
 data ZMQParameters = ZMQParameters
   { highWaterMark     :: Word64 -- uint64_t
-  , authMethod        :: AuthMethod
+  , authMethod        :: Maybe AuthMethod
   , minPort           :: Int
   , maxPort           :: Int
   , maxTries          :: Int
@@ -69,18 +69,16 @@ data ZMQParameters = ZMQParameters
 defaultZMQParameters :: ZMQParameters
 defaultZMQParameters = ZMQParameters
     { highWaterMark     = 0
-    , authMethod        = NoAuth
+    , authMethod        = Nothing
     , minPort           = 40000
     , maxPort           = 60000
     , maxTries          = 10000
     }
 
-data AuthMethod
-  = NoAuth
-  | AuthPlain
-    { authPlainPassword :: ByteString
-    , authPlainUserName :: ByteString
-    }
+data AuthMethod = AuthPlain
+  { authPlainPassword :: ByteString
+  , authPlainUserName :: ByteString
+  }
 
 type TransportAddress = ByteString
 


### PR DESCRIPTION
Change `AuthType` to `AuthMethod`, to avoid confusing with other meanings of the word "type". Use `Nothing` as identity because this is the usual identity when one needs one. More importantly, using no authentication arguably means there is no auth method, rather than meaning some null auth method.
