### PR TITLE
Use system mechanism to bind to random port.

### DIFF
--- a/src/Network/Transport/ZMQ/Internal/Types.hs
+++ b/src/Network/Transport/ZMQ/Internal/Types.hs
@@ -61,18 +61,12 @@ import qualified System.ZMQ4 as ZMQ
 data ZMQParameters = ZMQParameters
   { highWaterMark     :: Word64 -- uint64_t
   , authMethod        :: Maybe AuthMethod
-  , minPort           :: Int
-  , maxPort           :: Int
-  , maxTries          :: Int
   }
 
 defaultZMQParameters :: ZMQParameters
 defaultZMQParameters = ZMQParameters
     { highWaterMark     = 0
     , authMethod        = Nothing
-    , minPort           = 40000
-    , maxPort           = 60000
-    , maxTries          = 10000
     }
 
 data AuthMethod = AuthPlain


### PR DESCRIPTION
Use System.ZMQ4.lastEndPoint to obtain last bounded endpoint
and read port.

Changes:
- In ZMQParameters fields 'minPort', 'maxPort', 'maxTries' were
  dropped.
- Old functions for port binding in Network.Transport.Internal
  were dropped.
