### PR TITLE
Introduce 'distributed-process-tests' flag.

### DIFF
--- a/network-transport-zeromq.cabal
+++ b/network-transport-zeromq.cabal
@@ -18,6 +18,10 @@ flag install-benchmarks
   description: Install benchmarks executables (default benchmarks can be triggered during build using \-\-enable-benchmarks option).
   default:     False
 
+flag distributed-process-tests
+  description: build test suites that require distributed-process to be installed
+  default:     False
+
 flag unsafe
   description: Use faster but unsafe primitives.
   default:     False
@@ -53,7 +57,6 @@ library
   other-extensions:   CPP
   default-language:   Haskell2010
 
-
 Test-Suite test-zeromq
   type:               exitcode-stdio-1.0
   main-is:            TestZMQ.hs
@@ -79,13 +82,16 @@ Test-Suite test-api
   hs-source-dirs:     tests
   default-language:   Haskell2010
 
-
-
 Test-Suite test-ch-core
   Type:              exitcode-stdio-1.0
   Main-Is:           test-ch.hs
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.CH
-  Build-Depends:     base >= 4.4 && < 5,
+  default-extensions:        CPP
+  ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
+  HS-Source-Dirs:    tests
+  default-language:  Haskell2010
+  if flag(distributed-process-tests)
+    Build-Depends:   base >= 4.4 && < 5,
                      network-transport-zeromq,
                      distributed-process-tests >= 0.4,
                      network >= 2.3 && < 2.5,
@@ -95,17 +101,20 @@ Test-Suite test-ch-core
                      stm,
                      stm-chans,
                      bytestring
-  default-extensions:        CPP
-  ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
-  HS-Source-Dirs:    tests
-  default-language:  Haskell2010
-
+    Buildable:       True
+  else
+    Buildable:       False
 
 Test-Suite test-ch-closure
   Type:              exitcode-stdio-1.0
   Main-Is:           test-ch.hs
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Closure
-  Build-Depends:     base >= 4.4 && < 5,
+  default-extensions:        CPP
+  ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind -caf-all -auto-all
+  HS-Source-Dirs:    tests
+  default-language:  Haskell2010
+  if flag(distributed-process-tests)
+    Build-Depends:   base >= 4.4 && < 5,
                      network-transport-zeromq,
                      distributed-process-tests >= 0.4,
                      network >= 2.3 && < 2.5,
@@ -115,16 +124,20 @@ Test-Suite test-ch-closure
                      stm,
                      stm-chans,
                      bytestring
-  default-extensions:        CPP
-  ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind -caf-all -auto-all
-  HS-Source-Dirs:    tests
-  default-language:  Haskell2010
+    Buildable:       True
+  else
+    Buildable:       False
 
 Test-Suite test-ch-stat
   Type:              exitcode-stdio-1.0
   Main-Is:           test-ch.hs
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Stats
-  Build-Depends:     base >= 4.4 && < 5,
+  default-extensions:        CPP
+  ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
+  HS-Source-Dirs:    tests
+  default-language:  Haskell2010
+  if flag(distributed-process-tests)
+    Build-Depends:   base >= 4.4 && < 5,
                      network-transport-zeromq,
                      distributed-process-tests >= 0.4,
                      network >= 2.3 && < 2.5,
@@ -134,10 +147,9 @@ Test-Suite test-ch-stat
                      stm,
                      stm-chans,
                      bytestring
-  default-extensions:        CPP
-  ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
-  HS-Source-Dirs:    tests
-  default-language:  Haskell2010
+    Buildable:       True
+  else
+    Buildable:       False
 
 benchmark bench-channels-local
   type:              exitcode-stdio-1.0
@@ -185,14 +197,13 @@ benchmark bench-throughput-local
 
 executable bench-dp-latency
   main-is: Latency.hs
-  build-depends:     base >= 4.4 && < 5,
+  ghc-options:       -O2 -Wall
+  if flag(install-benchmarks)
+    build-depends:   base >= 4.4 && < 5,
                      network-transport-zeromq,
                      bytestring,
                      binary,
                      distributed-process
-  hs-source-dirs:    benchmarks
-  ghc-options:       -O2 -Wall
-  if flag(install-benchmarks)
     buildable:       True
   else
     buildable:       False


### PR DESCRIPTION
When this flag is enabled, we build and run distributed-process-tests,
with network-transport-zeromq. This may help to avoid boostraping
problem on CI machines and remove unnesessary tests.
