### PR TITLE
Hints

### DIFF
--- a/src/Network/Transport/ZMQ/Internal/Types.hs
+++ b/src/Network/Transport/ZMQ/Internal/Types.hs
@@ -41,6 +41,9 @@ module Network.Transport.ZMQ.Internal.Types
   , ZMQMulticastGroup(..)
   , MulticastGroupState(..)
   , ValidMulticastGroup(..)
+    -- * ZeroMQ specific types
+  , Hints(..)
+  , defaultHints
     -- * Internal data structures
   , Counter(..)
   , counterNextId
@@ -106,6 +109,8 @@ data TransportInternals = TransportInternals
   -- ^ Transport address (used as identifier).
   , transportState  :: !(MVar TransportState)
   -- ^ Internal state.
+  , transportParameters :: !ZMQParameters
+  -- ^ Parameters that were used to create the transport.
   }
 
 -- | Transport state.
@@ -208,6 +213,15 @@ data Counter a b = Counter
   { _counterNext   :: !a
   , _counterValue  :: !(Map a b)
   }
+
+-- | A list of Hints provided for connection
+data Hints = Hints
+  { hintsPort :: Maybe Int                   -- ^ The port to bind.
+  , hintsControlPort :: Maybe Int            -- ^ The port that is used to receive multicast messages.
+  }
+
+defaultHints :: Hints
+defaultHints = Hints Nothing Nothing
 
 nextElement :: (Enum a, Ord a)
             => (b -> IO Bool)

--- a/tests/TestAPI.hs
+++ b/tests/TestAPI.hs
@@ -20,6 +20,7 @@ main = defaultMain $
       , testCase "authentification" test_auth
       , testCase "connect to non existent host" test_nonexists
       , testCase "test cleanup actions" test_cleanup
+      , testCase "connect with prior knowledge" test_prior
       ]
 
 test_simple :: IO ()
@@ -121,3 +122,16 @@ test_cleanup = do
     closeTransport transport
     2 <- readIORef x
     return ()
+
+test_prior :: IO ()
+test_prior = do
+    (zmqa, _) <- createTransportExposeInternals defaultZMQParameters "127.0.0.1"
+    Right epa <- apiNewEndPoint defaultHints{hintsPort=Just 8888} zmqa
+
+    (_, transportb) <-
+          createTransportExposeInternals defaultZMQParameters "127.0.0.1"
+    Right epb <- newEndPoint transportb
+    Right _   <- connect epb (EndPointAddress "tcp://127.0.0.1:8888") ReliableOrdered defaultConnectHints
+    (ConnectionOpened 1 ReliableOrdered _) <- receive epa
+    return ()
+   


### PR DESCRIPTION
This commit introduces a new API that can be used for zeromq specific configuration and solving bootstrap problem that exists in n-t-zmq.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tweag/network-transport-zeromq/29)
<!-- Reviewable:end -->
